### PR TITLE
Add support for extracting comments from already open files (including ZipFile).

### DIFF
--- a/code_comment/__init__.py
+++ b/code_comment/__init__.py
@@ -9,8 +9,8 @@ from code_comment.models import Comment
 from code_comment.lib import Parser
 
 
-def extract(filepath):
-    return Parser(filepath)
+def extract(filepath, fileobj=None):
+    return Parser(filepath, fileobj)
 
 
 __all__ = ['Comment', 'extract']

--- a/code_comment/lib.py
+++ b/code_comment/lib.py
@@ -146,7 +146,7 @@ class Parser:
             fileobj = self.fileobj
 
         for line_number, text in enumerate(
-            [l.strip() if isinstance(l, str) else (l.decode()).strip() 
+            [l.strip() if isinstance(l, str) else (l.decode()).strip()
              for l in fileobj], start=1
         ):
             if not text:

--- a/code_comment/lib.py
+++ b/code_comment/lib.py
@@ -146,7 +146,8 @@ class Parser:
             fileobj = self.fileobj
 
         for line_number, text in enumerate(
-            [l.strip() for l in fileobj], start=1
+            [l.strip() if isinstance(l, str) else (l.decode()).strip() 
+             for l in fileobj], start=1
         ):
             if not text:
                 continue


### PR DESCRIPTION
Hi,
The patch adds an optional argument for passing an already open file handle/object as  optional parameter to the extract method. Moreover, if this file is in binary mode, the input is automatically decoded. 

This allows, e.g., the use of the ZipFile module to extract comments from source code that is stored in a zip file without extracting the files explicitly. Let's assume we have a zip file called 'src.zip' that contains the file 'src/dummy.py', then we can extract the comments as follows:

``` python
#!/usr/bin/python3
import code_comment
from zipfile import ZipFile

filepath = 'src/dummy.py'

with ZipFile("src.zip", 'r') as z:
    with z.open(filepath) as f:
        for comment in code_comment.extract(filepath,f):
            print(str(comment))
```

Best,
Achim 


