### PR TITLE
Fix/python multiline comments

### DIFF
--- a/code_comment/lib.py
+++ b/code_comment/lib.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os.path
+import re
 
 from code_comment.models import Comment
 from code_comment.errors import CodeLanguageUnsupported
@@ -154,6 +155,9 @@ class Parser:
         def is_currently_multi_line_comment():
             return bool(tmp)
 
+        def is_python():
+            return self.determine_code_language() == 'python'
+
         def is_single_line_comment(text):
             return (
                 not is_currently_multi_line_comment()
@@ -166,13 +170,14 @@ class Parser:
                 not is_currently_multi_line_comment()
                 and text.startswith(mlc_header)
                 and text.endswith(mlc_footer)
+                and len(text) >= 6
             )
 
         def is_multi_line_comment_start(text):
             return (
                 not is_currently_multi_line_comment()
                 and text.startswith(mlc_header)
-                and not text.endswith(mlc_footer)
+                and (not text.endswith(mlc_footer) or len(text) == 3)
             )
 
         def is_multi_line_comment_midst(text):
@@ -189,14 +194,49 @@ class Parser:
                 and text.endswith(mlc_footer)
             )
 
+        def is_multi_line_print_starts(text):
+            return (
+                is_python()
+                and re.search(r'(?!^)"""', text, re.M)
+                and not is_single_line_comment_multiline_notation(text)
+            )
+
+        def is_multi_line_print_in_single_line(text):
+            return (
+               is_python()
+               and (len(re.findall(r'(?!^)"""', text, re.M)) >= 2)
+            )
+
+        flag = 0
         with open(self.filepath, 'r') as f:
             for line_number, text in enumerate(
                 [l.strip() for l in f], start=1
             ):
+                text = re.sub(r"'''", '"""', text)
+
                 if not text:
                     continue
 
-                if is_single_line_comment(text):
+                if is_multi_line_print_in_single_line(text):
+                    # Start and End of Multiline python comment in Single line
+                    flag = 0
+                    continue
+
+                elif is_multi_line_print_starts(text):
+                    # Multi line print starts
+                    flag = 1
+                    continue
+
+                elif is_python() and flag == 1 and bool(re.search(r'"""', text)):
+                    # Multi line print ends
+                    flag = 0
+                    continue
+
+                elif is_python() and flag == 1:
+                    # Multi line print continues
+                    continue
+
+                elif is_single_line_comment(text):
                     comment_text = text.split(slc_header)[1].strip()
                     yield Comment(comment_text, self.filepath, line_number)
 

--- a/code_comment/lib.py
+++ b/code_comment/lib.py
@@ -11,6 +11,12 @@ class CodeLanguage:
     PHP = 'php'
     JAVASCRIPT = 'javascript'
     GOLANG = 'go'
+    CPP = 'cpp'
+    C = 'c'
+    JAVA = 'java'
+    H = 'h'
+    CSS = 'css'
+    HTML = 'html'
 
     @staticmethod
     def factory(code_name):
@@ -22,6 +28,18 @@ class CodeLanguage:
             return JavascriptCodeLanguage
         elif code_name == CodeLanguage.GOLANG:
             return GolangCodeLanguage
+        elif code_name == CodeLanguage.CPP:
+            return CppCodeLanguage
+        elif code_name == CodeLanguage.C:
+            return CCodeLanguage
+        elif code_name == CodeLanguage.JAVA:
+            return JavaCodeLanguage
+        elif code_name == CodeLanguage.H:
+            return CppHeaderCodeLanguage
+        elif code_name == CodeLanguage.CSS:
+            return CSSCodeLanguage
+        elif code_name == CodeLanguage.HTML:
+            return HTMLCodeLanguage
         raise CodeLanguageUnsupported
 
 
@@ -37,13 +55,37 @@ class JavascriptCodeLanguage(BaseCodeLanguage):
     pass
 
 
+class CSSCodeLanguage(BaseCodeLanguage):
+    pass
+
+
 class GolangCodeLanguage(BaseCodeLanguage):
+    pass
+
+
+class CppCodeLanguage(BaseCodeLanguage):
+    pass
+
+
+class CCodeLanguage(BaseCodeLanguage):
+    pass
+
+
+class JavaCodeLanguage(BaseCodeLanguage):
+    pass
+
+
+class CppHeaderCodeLanguage(BaseCodeLanguage):
     pass
 
 
 class PHPCodeLanguage(BaseCodeLanguage):
     # NOTE: assuming PHPDoc style
     MULTI_LINE_COMMENT = ('/**', '*', '*/')
+
+
+class HTMLCodeLanguage(BaseCodeLanguage):
+    MULTI_LINE_COMMENT = ('<!--', None, '-->')
 
 
 class PythonCodeLanguage(CodeLanguage):
@@ -58,7 +100,15 @@ class Parser:
         'py': CodeLanguage.PYTHON,
         'php': CodeLanguage.PHP,
         'js': CodeLanguage.JAVASCRIPT,
-        'go': CodeLanguage.GOLANG
+        'go': CodeLanguage.GOLANG,
+        'cpp': CodeLanguage.CPP,
+        'cc': CodeLanguage.CPP,
+        'c': CodeLanguage.C,
+        'java': CodeLanguage.JAVA,
+        'h': CodeLanguage.H,
+        'hpp': CodeLanguage.H,
+        'css': CodeLanguage.CSS,
+        'html': CodeLanguage.HTML
     }
 
     @staticmethod

--- a/code_comment/lib.py
+++ b/code_comment/lib.py
@@ -227,7 +227,7 @@ class Parser:
                     flag = 1
                     continue
 
-                elif is_python() and flag == 1 and bool(re.search(r'"""', text)):
+                elif is_python() and flag and bool(re.search(r'"""', text)):
                     # Multi line print ends
                     flag = 0
                     continue

--- a/tests/fixtures/dummy.py
+++ b/tests/fixtures/dummy.py
@@ -13,9 +13,9 @@ if __name__ == '__main__':
     """ Test single-line multiline comment """
     print(""" Multi line print statement in a single line """)
     print("""
-    	This statement should not be printed 
-    	as it is Multi line print statement
-    	""")
+        This statement should not be printed
+        as it is Multi line print statement
+        """)
     """Testing multi-line comment after Multi-line print statement"""
-    
+
     main()

--- a/tests/fixtures/dummy.py
+++ b/tests/fixtures/dummy.py
@@ -11,4 +11,11 @@ def main():
 
 if __name__ == '__main__':
     """ Test single-line multiline comment """
+    print(""" Multi line print statement in a single line """)
+    print("""
+    	This statement should not be printed 
+    	as it is Multi line print statement
+    	""")
+    """Testing multi-line comment after Multi-line print statement"""
+    
     main()

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -72,8 +72,8 @@ def test_parser_init_fail():
 def test_parser_parse_python_success():
     parser = Parser(os.path.join(FIXTURE_DIR, 'dummy.py'))
     comments = list(parser)
-
-    assert len(comments) == 4
+    
+    assert len(comments) == 5
 
     assert comments[0].line_number_str == '1~3'
     assert comments[0].is_multiline
@@ -90,3 +90,7 @@ def test_parser_parse_python_success():
     assert comments[3].line_number_str == '13'
     assert not comments[3].is_multiline
     assert comments[3].body_str == 'Test single-line multiline comment'
+
+    assert comments[4].line_number_str == '19'
+    assert not comments[4].is_multiline
+    assert comments[4].body_str == 'Testing multi-line comment after Multi-line print statement'

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -9,6 +9,12 @@ from code_comment.lib import (
     PHPCodeLanguage,
     GolangCodeLanguage,
     JavascriptCodeLanguage,
+    CppCodeLanguage,
+    CCodeLanguage,
+    JavaCodeLanguage,
+    CppHeaderCodeLanguage,
+    CSSCodeLanguage,
+    HTMLCodeLanguage,
     Parser
 )
 from code_comment.errors import CodeLanguageUnsupported
@@ -23,7 +29,13 @@ def test_code_language_factory_success():
         ('go', GolangCodeLanguage),
         ('javascript', JavascriptCodeLanguage),
         ('php', PHPCodeLanguage),
-        ('python', PythonCodeLanguage)
+        ('python', PythonCodeLanguage),
+        ('cpp', CppCodeLanguage),
+        ('c', CCodeLanguage),
+        ('java', JavaCodeLanguage),
+        ('h', CppHeaderCodeLanguage),
+        ('css', CSSCodeLanguage),
+        ('html', HTMLCodeLanguage)
     ]:
         klass = CodeLanguage.factory(language)
         assert klass == KodeLanguage
@@ -36,14 +48,14 @@ def test_code_language_factory_fail():
 
 def test_parser_is_supported_code_extension_success():
     for ext in [
-        'php', 'py', 'go', 'js'
+        'php', 'py', 'go', 'js', 'cpp', 'cc', 'c', 'java', 'h', 'hpp', 'css', 'html'
     ]:
         assert Parser.is_supported_code_extension(ext) is True
 
 
 def test_parser_is_supported_code_extension_fail():
     for ext in [
-        '', None, 'cpp', 'rb'
+        '', None, 'rb', 'sh'
     ]:
         assert Parser.is_supported_code_extension(ext) is False
 

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -48,7 +48,8 @@ def test_code_language_factory_fail():
 
 def test_parser_is_supported_code_extension_success():
     for ext in [
-        'php', 'py', 'go', 'js', 'cpp', 'cc', 'c', 'java', 'h', 'hpp', 'css', 'html'
+        'php', 'py', 'go', 'js', 'cpp', 'cc', 'c', 'java', 'h', 'hpp',
+        'css', 'html'
     ]:
         assert Parser.is_supported_code_extension(ext) is True
 
@@ -72,7 +73,7 @@ def test_parser_init_fail():
 def test_parser_parse_python_success():
     parser = Parser(os.path.join(FIXTURE_DIR, 'dummy.py'))
     comments = list(parser)
-    
+
     assert len(comments) == 5
 
     assert comments[0].line_number_str == '1~3'
@@ -93,4 +94,5 @@ def test_parser_parse_python_success():
 
     assert comments[4].line_number_str == '19'
     assert not comments[4].is_multiline
-    assert comments[4].body_str == 'Testing multi-line comment after Multi-line print statement'
+    assert comments[4].body_str == 'Testing multi-line comment after \
+Multi-line print statement'


### PR DESCRIPTION
Initially, multi-line print statements can confuse further multi-line comments in python.
Updated the code to ignore the multi-line print statements in python. Also, updated the test cases regarding the issue.
@kelvintaywl Please check.
